### PR TITLE
TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ opusscript
 
 ```js
 var opusscript = require("opusscript");
-/*
-TypeScript:
-@code `import opusscript = require('opusscript');`
-DO NOT USE
-@code `import OpusScript from 'opusscript';`
-***the module resolves to a class and cannot be imported as so***
-*/
 
 // 48kHz sampling rate, 20ms frame duration, stereo audio (2 channels)
 var samplingRate = 48000;
@@ -32,3 +25,15 @@ var decodedPacket = encoder.decode(encodedPacket);
 // Delete the encoder when finished with it (Emscripten does not automatically call C++ object destructors)
 encoder.delete();
 ```
+
+
+### For TypeScript
+Import using
+```ts
+import opusscript = require('opusscript');
+```
+**NOT**
+```ts
+import OpusScript from 'opusscript';
+```
+***The module resolves to a class and cannot be imported as so***

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ var decodedPacket = encoder.decode(encodedPacket);
 encoder.delete();
 ```
 
+#### TypeScript
 
-### For TypeScript
-Import using
+Since this module wasn't written for TypeScript, you need to use `import = require` syntax.
+
 ```ts
-import opusscript = require('opusscript');
-```
-**NOT**
-```ts
+// Import using:
+import OpusScript = require('opusscript');
+
+// and NOT:
 import OpusScript from 'opusscript';
 ```
-***The module resolves to a class and cannot be imported as so***

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ opusscript
 
 ```js
 var opusscript = require("opusscript");
+/*
+TypeScript:
+@code `import opusscript = require('opusscript');`
+DO NOT USE
+@code `import OpusScript from 'opusscript';`
+***the module resolves to a class and cannot be imported as so***
+*/
 
 // 48kHz sampling rate, 20ms frame duration, stereo audio (2 channels)
 var samplingRate = 48000;

--- a/opusscript.d.ts
+++ b/opusscript.d.ts
@@ -68,8 +68,8 @@ declare module 'opusscript' {
          * Decode an opus buffer
          */
         decode(buffer: Buffer): Buffer;
-        encoderCTL(ctl: any, arg: any): void;
-        decoderCTL(ctl: any, arg: any): void;
+        encoderCTL(ctl: number, arg: number): void;
+        decoderCTL(ctl: number, arg: number): void;
         /**
          * Delete the opus object
          */

--- a/opusscript.d.ts
+++ b/opusscript.d.ts
@@ -17,7 +17,7 @@ declare module 'opusscript' {
     type VALID_SAMPLING_RATES = 8000 | 12000 | 16000 | 24000 | 48000;
     type MAX_FRAME_SIZE = 2880;
     type MAX_PACKET_SIZE = 3828;
-    class OpusScript {
+    export default class OpusScript {
         OpusApplication: typeof OpusApplication;
         Error: typeof OpusError;
         VALID_SAMPLING_RATES: [8000, 12000, 16000, 24000, 48000];
@@ -30,5 +30,4 @@ declare module 'opusscript' {
         decoderCTL(ctl: any, arg: any): void;
         delete(): void;
     }
-    export = OpusScript;
 }

--- a/opusscript.d.ts
+++ b/opusscript.d.ts
@@ -1,0 +1,34 @@
+declare module 'opusscript' {
+    enum OpusApplication {
+        VOIP = 2048,
+        AUDIO = 2049,
+        RESTRICTED_LOWDELAY = 2051
+    }
+    enum OpusError {
+        "OK" = 0,
+        "Bad argument" = -1,
+        "Buffer too small" = -2,
+        "Internal error" = -3,
+        "Invalid packet" = -4,
+        "Unimplemented" = -5,
+        "Invalid state" = -6,
+        "Memory allocation fail" = -7
+    }
+    type VALID_SAMPLING_RATES = 8000 | 12000 | 16000 | 24000 | 48000;
+    type MAX_FRAME_SIZE = 2880;
+    type MAX_PACKET_SIZE = 3828;
+    class OpusScript {
+        OpusApplication: typeof OpusApplication;
+        Error: typeof OpusError;
+        VALID_SAMPLING_RATES: [8000, 12000, 16000, 24000, 48000];
+        MAX_PACKET_SIZE: MAX_PACKET_SIZE;
+
+        constructor(samplingRate: VALID_SAMPLING_RATES, channels?: number, application?: OpusApplication);
+        encode(buffer: Buffer, frameSize: number): Buffer;
+        decode(buffer: Buffer): Buffer;
+        encoderCTL(ctl: any, arg: any): void;
+        decoderCTL(ctl: any, arg: any): void;
+        delete(): void;
+    }
+    export = OpusScript;
+}

--- a/opusscript.d.ts
+++ b/opusscript.d.ts
@@ -17,11 +17,11 @@ declare module 'opusscript' {
     type VALID_SAMPLING_RATES = 8000 | 12000 | 16000 | 24000 | 48000;
     type MAX_FRAME_SIZE = 2880;
     type MAX_PACKET_SIZE = 3828;
-    export default class OpusScript {
-        OpusApplication: typeof OpusApplication;
-        Error: typeof OpusError;
-        VALID_SAMPLING_RATES: [8000, 12000, 16000, 24000, 48000];
-        MAX_PACKET_SIZE: MAX_PACKET_SIZE;
+    class OpusScript {
+        static Application: typeof OpusApplication;
+        static Error: typeof OpusError;
+        static VALID_SAMPLING_RATES: [8000, 12000, 16000, 24000, 48000];
+        static MAX_PACKET_SIZE: MAX_PACKET_SIZE;
 
         constructor(samplingRate: VALID_SAMPLING_RATES, channels?: number, application?: OpusApplication);
         encode(buffer: Buffer, frameSize: number): Buffer;
@@ -30,4 +30,5 @@ declare module 'opusscript' {
         decoderCTL(ctl: any, arg: any): void;
         delete(): void;
     }
+    export = OpusScript;
 }

--- a/opusscript.d.ts
+++ b/opusscript.d.ts
@@ -1,7 +1,19 @@
 declare module 'opusscript' {
+    /**
+     * Opus application type
+     */
     enum OpusApplication {
+        /**
+         * Voice Over IP
+         */
         VOIP = 2048,
+        /**
+         * Audio
+         */
         AUDIO = 2049,
+        /**
+         * 
+         */
         RESTRICTED_LOWDELAY = 2051
     }
     enum OpusError {
@@ -14,20 +26,53 @@ declare module 'opusscript' {
         "Invalid state" = -6,
         "Memory allocation fail" = -7
     }
+    /**
+     *  Valid audio sampling rates
+     */
     type VALID_SAMPLING_RATES = 8000 | 12000 | 16000 | 24000 | 48000;
+    /**
+     * Maximum bytes in a frame
+     */
     type MAX_FRAME_SIZE = 2880;
+    /**
+     * Maximum bytes in a packet
+     */
     type MAX_PACKET_SIZE = 3828;
     class OpusScript {
+        /**
+         * Different Opus application types
+         */
         static Application: typeof OpusApplication;
+        /**
+         * Opus Error codes
+         */
         static Error: typeof OpusError;
+        /**
+         * Array of sampling rates that Opus can use
+         */
         static VALID_SAMPLING_RATES: [8000, 12000, 16000, 24000, 48000];
+        /**
+         * The maximum size (in bytes) to send in a packet
+         */
         static MAX_PACKET_SIZE: MAX_PACKET_SIZE;
 
+        /**
+         * Create a new Opus en/decoder
+         */
         constructor(samplingRate: VALID_SAMPLING_RATES, channels?: number, application?: OpusApplication);
+        /**
+         * Encode a buffer into Opus
+         */
         encode(buffer: Buffer, frameSize: number): Buffer;
+        /**
+         * Decode an opus buffer
+         */
         decode(buffer: Buffer): Buffer;
         encoderCTL(ctl: any, arg: any): void;
         decoderCTL(ctl: any, arg: any): void;
+        /**
+         * Delete the opus object
+         */
         delete(): void;
     }
     export = OpusScript;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.4",
   "description": "JS bindings for libopus 1.2.1, ported with emscripten",
   "main": "index.js",
+  "types": "opusscript.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/abalabahaha/opusscript.git"


### PR DESCRIPTION
I added a typescript deceleration file, so this package should work with typescript

below is a list of things I didn't add:
 - types for `encoderCTL`'s parameters
 - types for `decoderCTL`'s parameters
 - method descriptions for the above