### PR TITLE
feat: add setBitrate() helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,9 +83,12 @@ declare module 'opusscript' {
          */
         decode(buffer: Buffer): Buffer;
         /**
+         * Set the encoder bitrate
+         */
+        setBitrate(bitrate: number): void;
+        /**
          * Encoder/decoder parameters
          */
-        encoderBitRate(val: number): void;
         encoderCTL(ctl: number, arg: number): void;
         decoderCTL(ctl: number, arg: number): void;
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,10 @@ declare module 'opusscript' {
          * Decode an opus buffer
          */
         decode(buffer: Buffer): Buffer;
+        /**
+         * Encoder/decoder parameters
+         */
+        encoderBitRate(val: number): void;
         encoderCTL(ctl: number, arg: number): void;
         decoderCTL(ctl: number, arg: number): void;
         /**

--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ OpusScript.prototype.encoderCTL = function encoderCTL(ctl, arg) {
     }
 };
 
+OpusScript.prototype.encoderBitRate = function encoderBitRate(val) {
+    this.encoderCTL(4002, val);
+};
+
 OpusScript.prototype.decoderCTL = function decoderCTL(ctl, arg) {
     var len = this.handler._decoder_ctl(ctl, arg);
     if(len < 0) {

--- a/index.js
+++ b/index.js
@@ -92,8 +92,8 @@ OpusScript.prototype.encoderCTL = function encoderCTL(ctl, arg) {
     }
 };
 
-OpusScript.prototype.encoderBitRate = function encoderBitRate(val) {
-    this.encoderCTL(4002, val);
+OpusScript.prototype.setBitrate = function setBitrate(bitrate) {
+    this.encoderCTL(4002, bitrate);
 };
 
 OpusScript.prototype.decoderCTL = function decoderCTL(ctl, arg) {


### PR DESCRIPTION
This is just a simple function, essentially an alias to `encoderCTL`: `this.encoderCTL(4002, val)`. It would be nice to have it in the library itself though, rater than the projects that depend on it as they won't have to carry this magic number around.