### PR TITLE
fix: export missing _free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OPUS_NATIVE_DIR=./opus-native
 
-EMCC_OPTS=-Wall -O3 --llvm-lto 3 -flto --closure 1 -s ALLOW_MEMORY_GROWTH=1 --memory-init-file 0 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS="['setValue', 'getValue']" -s EXPORTED_FUNCTIONS="['_malloc', '_opus_strerror']" -s MODULARIZE=1 -s NODEJS_CATCH_EXIT=0 -s NODEJS_CATCH_REJECTION=0
+EMCC_OPTS=-Wall -O3 --llvm-lto 3 -flto --closure 1 -s ALLOW_MEMORY_GROWTH=1 --memory-init-file 0 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS="['setValue', 'getValue']" -s EXPORTED_FUNCTIONS="['_malloc', '_opus_strerror', '_free']" -s MODULARIZE=1 -s NODEJS_CATCH_EXIT=0 -s NODEJS_CATCH_REJECTION=0
 
 EMCC_NASM_OPTS=-s WASM=0 -s WASM_ASYNC_COMPILATION=0
 EMCC_WASM_OPTS=-s WASM=1 -s WASM_ASYNC_COMPILATION=0 -s WASM_BIGINT


### PR DESCRIPTION
export  missing _free in emscript compile

This solves a bug when calling `destroy` it would crash with _free is undefined error